### PR TITLE
Add skip name resolution and skip host cache properties in the default configuration

### DIFF
--- a/src/main/resources/mariadb-default-conf/my.cnf
+++ b/src/main/resources/mariadb-default-conf/my.cnf
@@ -10,6 +10,8 @@ read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K
 thread_stack = 512K
+skip-host-cache
+skip-name-resolve
 
 # Don't listen on a TCP/IP port at all. This can be a security enhancement,
 # if all processes that need to connect to mysqld run on the same host.

--- a/src/test/resources/somepath/mariadb_conf_override/my.cnf
+++ b/src/test/resources/somepath/mariadb_conf_override/my.cnf
@@ -10,6 +10,8 @@ read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K
 thread_stack = 128K
+skip-host-cache
+skip-name-resolve
 
 
 innodb_file_format=Barracuda


### PR DESCRIPTION
Add docker-specific properties, see mysql's configuration and default configuration of the official mariadb image:
https://github.com/testcontainers/testcontainers-java/blob/master/modules/mysql/src/main/resources/mysql-default-conf/my.cnf#L15
https://github.com/docker-library/mariadb/blob/1037a0b7ab09343e011826078fbdffb0bf465fc3/10.3/Dockerfile#L112

Without them, all requests to mariadb container are super slow, if docker configuration has no configured dns server. 